### PR TITLE
fix: 팀스케줄이 스케줄 dto를 상속받아 생기는 오류를 수정

### DIFF
--- a/src/main/java/com/example/groom/domain/schedule/dto/ScheduleDto.java
+++ b/src/main/java/com/example/groom/domain/schedule/dto/ScheduleDto.java
@@ -1,6 +1,5 @@
 package com.example.groom.domain.schedule.dto;
 
-import com.example.groom.domain.schedule.teamSchedule.dto.TeamSchedulePostDto;
 import lombok.Data;
 
 import java.time.LocalDateTime;
@@ -13,10 +12,4 @@ public class ScheduleDto {
     private LocalDateTime startTime;
 
     private LocalDateTime endTime;
-
-    public ScheduleDto(TeamSchedulePostDto teamSchedulePostDto) {
-        this.title = teamSchedulePostDto.getTitle();
-        this.startTime = teamSchedulePostDto.getStartTime();
-        this.endTime = teamSchedulePostDto.getEndTime();
-    }
 }

--- a/src/main/java/com/example/groom/domain/schedule/teamSchedule/dto/TeamScheduleDto.java
+++ b/src/main/java/com/example/groom/domain/schedule/teamSchedule/dto/TeamScheduleDto.java
@@ -1,19 +1,27 @@
 package com.example.groom.domain.schedule.teamSchedule.dto;
 
-import com.example.groom.domain.schedule.dto.ScheduleDto;
 import com.example.groom.entity.domain.room.Room;
 import com.example.groom.entity.domain.schedule.MeetingLocation;
 import lombok.Data;
 
-@Data
-public class TeamScheduleDto extends ScheduleDto {
+import java.time.LocalDateTime;
 
+@Data
+public class TeamScheduleDto {
+
+    private String title;
+
+    private LocalDateTime startTime;
+
+    private LocalDateTime endTime;
     private MeetingLocation meetingLocation;
 
     private Room room;
 
     public TeamScheduleDto(TeamSchedulePostDto teamSchedulePostDto, Room room) {
-        super(teamSchedulePostDto);
+        this.title = teamSchedulePostDto.getTitle();
+        this.startTime = teamSchedulePostDto.getStartTime();
+        this.endTime = teamSchedulePostDto.getEndTime();
         this.meetingLocation = teamSchedulePostDto.getMeetingLocation();
         this.room = room;
     }

--- a/src/main/java/com/example/groom/domain/schedule/teamSchedule/dto/TeamSchedulePostDto.java
+++ b/src/main/java/com/example/groom/domain/schedule/teamSchedule/dto/TeamSchedulePostDto.java
@@ -1,11 +1,18 @@
 package com.example.groom.domain.schedule.teamSchedule.dto;
 
-import com.example.groom.domain.schedule.dto.ScheduleDto;
 import com.example.groom.entity.domain.schedule.MeetingLocation;
 import lombok.Data;
 
+import java.time.LocalDateTime;
+
 @Data
-public class TeamSchedulePostDto extends ScheduleDto {
+public class TeamSchedulePostDto {
+
+    private String title;
+
+    private LocalDateTime startTime;
+
+    private LocalDateTime endTime;
 
     private MeetingLocation meetingLocation;
 


### PR DESCRIPTION
팀 스케줄줄dto가 스케줄 dto를 상속받지 않고 개별 컬럼을 갖도록 수정함

## 💡 이슈
resolve #64

## 🤩 개요
PR의 개요를 적어주세요.

## 🧑‍💻 작업 사항
작업한 내용을 적어주세요.

## 📖 참고 사항
공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요.